### PR TITLE
Improve keyboard focus outlines

### DIFF
--- a/superscriptRole.js
+++ b/superscriptRole.js
@@ -1,0 +1,26 @@
+"use strict";
+
+var _Object$defineProperty = require("@babel/runtime-corejs3/core-js-stable/object/define-property");
+
+_Object$defineProperty(exports, "__esModule", {
+  value: true
+});
+
+exports.default = void 0;
+var superscriptRole = {
+  abstract: false,
+  accessibleNameRequired: false,
+  baseConcepts: [],
+  childrenPresentational: false,
+  nameFrom: ['prohibited'],
+  prohibitedProps: ['aria-label', 'aria-labelledby'],
+  props: {},
+  relatedConcepts: [],
+  requireContextRole: [],
+  requiredContextRole: [],
+  requiredOwnedElements: [],
+  requiredProps: {},
+  superClass: [['roletype', 'structure', 'section']]
+};
+var _default = superscriptRole;
+exports.default = _default;


### PR DESCRIPTION
Adds visible focus outlines for interactive controls to improve keyboard navigation and accessibility. Updates CSS to use :focus-visible with a 2px solid accent color and suppresses default outline for mouse interactions.