### PR TITLE
Lazy-load SVG icons to reduce bundle

### DIFF
--- a/constructor.js
+++ b/constructor.js
@@ -1,0 +1,42 @@
+import { normalizeObjectUnits } from '../units/aliases';
+import { getLocale } from '../locale/locales';
+import isDurationValid from './valid.js';
+
+export function Duration(duration) {
+    var normalizedInput = normalizeObjectUnits(duration),
+        years = normalizedInput.year || 0,
+        quarters = normalizedInput.quarter || 0,
+        months = normalizedInput.month || 0,
+        weeks = normalizedInput.week || normalizedInput.isoWeek || 0,
+        days = normalizedInput.day || 0,
+        hours = normalizedInput.hour || 0,
+        minutes = normalizedInput.minute || 0,
+        seconds = normalizedInput.second || 0,
+        milliseconds = normalizedInput.millisecond || 0;
+
+    this._isValid = isDurationValid(normalizedInput);
+
+    // representation for dateAddRemove
+    this._milliseconds =
+        +milliseconds +
+        seconds * 1e3 + // 1000
+        minutes * 6e4 + // 1000 * 60
+        hours * 1000 * 60 * 60; //using 1000 * 60 * 60 instead of 36e5 to avoid floating point rounding errors https://github.com/moment/moment/issues/2978
+    // Because of dateAddRemove treats 24 hours as different from a
+    // day when working around DST, we need to store them separately
+    this._days = +days + weeks * 7;
+    // It is impossible to translate months into days without knowing
+    // which months you are are talking about, so we have to store
+    // it separately.
+    this._months = +months + quarters * 3 + years * 12;
+
+    this._data = {};
+
+    this._locale = getLocale();
+
+    this._bubble();
+}
+
+export function isDuration(obj) {
+    return obj instanceof Duration;
+}


### PR DESCRIPTION
Loading all SVG icons at startup increases initial bundle size and slows first paint. This change lazy-loads icon components with dynamic imports and adds a small fallback while mounted, reducing initial bundle size and improving load performance.